### PR TITLE
[rail_section] ordered_pt_objects only uri

### DIFF
--- a/chaos.proto
+++ b/chaos.proto
@@ -120,7 +120,7 @@ message LineSection{
 }
 
 message OrderedPtObject{
- required PtObject pt_object = 1;
+ required string uri = 1;
  required uint32 order = 2;
 }
 


### PR DESCRIPTION
Ordered_pt_objects will only get 'uri' info and not a full PtObject